### PR TITLE
Prevents illegal save on consecutive submits with invalid entries.

### DIFF
--- a/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
+++ b/Modules/Test/classes/class.ilTestPlayerAbstractGUI.php
@@ -2897,7 +2897,8 @@ abstract class ilTestPlayerAbstractGUI extends ilTestServiceGUI
 		// set the initial state of the question
 		$state = $questionGUI->object->lookupForExistingSolutions($this->testSession->getActiveId(), $this->testSession->getPass());
 		$config['isAnswered'] = $state['authorized'];
-		$config['isAnswerChanged'] = $state['intermediate'] || $this->getAnswerChangedParameter();
+		$hadSaveError = isset($_GET['save_error']) && $_GET['save_error'] == 1;
+		$config['isAnswerChanged'] = $state['intermediate'] || $this->getAnswerChangedParameter() || $hadSaveError;
 
 		// set  url to which the for should be submitted when the working time is over
 		// don't use asynch url because the form is submitted directly


### PR DESCRIPTION
Leider gibt es beim Speichern von illegalen Werten auch in 5.13.12+ noch ein Problem: zwar wird die erste Speicherung verhindert, bei einem wiederholten Submit gehen die Daten aber wieder verloren, vgl. folgendes Video:

[ilias-save-error.mov.zip](https://github.com/bheyser/ILIAS/files/2759229/ilias-save-error.mov.zip)

Dieser PR behebt das Problem, indem der `save_error` der vorherigen Speicherung (vgl. `ilTestOutputGUI::saveQuestionSolution`) überprüft wird; gab es einen solchen error (z.B. wegen. einer fehlgeschlagenen Validierung in `assClozeTest::validateSolutionSubmit`) wird davon ausgegangen, dass die Frage im Zustand "verändert" ist, also auf jeden Fall nochmal gespeichert werden muss. Der momentane Fehler liegt - anders herum betrachtet - daran, dass die Frage trotz der Änderungen, die nicht validiert und damit gespeichert wurden, in den Zustand "unverändert" geht.
